### PR TITLE
Create all directories under the homebrew user

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,6 +14,7 @@ class homebrew::install {
     if !defined(File[$brew_sys_folder]) {
       file { $brew_sys_folder:
         ensure => directory,
+        user   => $homebrew::user,
         group  => $homebrew::group,
       }
     }


### PR DESCRIPTION
When running
```
puppet agent --test
```
under the root user and letting puppet install homebrew, I end up with a `/usr/local/lib/pkgconfig` directory which has the `root` as owner and the `$homebrew::group` as group.

When installing packages that try to access `/usr/local/lib/pkgconfig`, they are denied permission to that folder because the installation of the packages uses the `$homebrew::user`.

Seeing as this module allows to specify the user under which you want to install homebrew, I don't see the reason why we should use another user for creating those folders.