### PR TITLE
Added /usr/local/sbin to the list of folders

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,6 +3,7 @@ class homebrew::install {
 
   $brew_sys_folders = [
     '/usr/local/bin',
+    '/usr/local/sbin',
     '/usr/local/etc',
     '/usr/local/Frameworks',
     '/usr/local/include',


### PR DESCRIPTION
For example the `netdata` package (`brew install netdata`) requires that folder to install a symlink in there.